### PR TITLE
Fix bear field data save

### DIFF
--- a/web/bhims.php
+++ b/web/bhims.php
@@ -257,10 +257,11 @@ if (isset($_POST['action'])) {
 					}
 
 					$result = runQueryWithinTransaction($conn, $_POST['queryString'][$i], $params);
-					if (strpos(json_encode($result), 'ERROR') !== false) {
+					$stringifiedResult = json_encode($result);
+					if (strpos($stringifiedResult, 'ERROR') !== false) {
 						// roll back the previous queries
 						pg_query($conn, 'ROLLBACK');
-						echo $result, " from the query $i ", $_POST['queryString'][$i], ' with params ', json_encode($params);
+						echo $stringifiedResult, " from the query $i ", $_POST['queryString'][$i], ' with params ', json_encode($params);
 						exit();
 					}
 

--- a/web/js/bhims-custom.js
+++ b/web/js/bhims-custom.js
@@ -68,6 +68,27 @@ function customizeQuery() {
 		$('#bears-accordion').siblings('.add-item-container').addClass('hidden');
 	}
 
+	BHIMSQuery.prototype.beforeSaveCustomAction = function(sqlStatements, sqlParameters) {
+		const tablesToBeUpdated = $('.input-field.dirty').map((_, el) => $(el).data('table-name')).get();
+		
+
+		const encounterID = this.selectedID;
+		// Add DELETE SQL statement to clear the table before insert. We want to add
+		//	the SQL to the sqlStatements so the DELETE and INSERTs all happen in the
+		//	same transaction in case one produces an error
+		if (tablesToBeUpdated.includes('bears')) {
+			return [ 
+				[`DELETE FROM bears WHERE encounter_id=$1`].concat(sqlStatements),
+				[[encounterID]].concat(sqlParameters)
+			]
+		} else {
+			return [sqlStatements, sqlParameters]
+		}
+
+	}
+
+
 	bhimsQuery.dataLoadedFunctions.push(bhimsQuery.setDENABearFields)
 }
+
 


### PR DESCRIPTION
### query,js
- Added customizable dummy method that can be overridden in bhims-custom.js
- Fixed bug when getting ID from the RETURNING clause of INSERT SQL for one-to-many tables
- Fixed bug to retrieve DB row ID for updates of one-to-many tables

### bhims-custom.js
- implemented template function executed just before saving query data updates to delete `bears` table rows before INSERTing new ones

### bhims.php
- modified format of error message from param queries to be more informative 