### PR TITLE
prevent previous encounter from polluting new selection

### DIFF
--- a/web/js/bhims.js
+++ b/web/js/bhims.js
@@ -1,3 +1,26 @@
+function deepCopy(inObject) {
+	/*
+	Return a true deep copy of an object
+	*/
+	
+	let outObject, value, key;
+
+	if (typeof inObject !== "object" || inObject === null) {
+		return inObject; // Return the value if inObject is not an object
+	}
+
+	// Create an array or object to hold the values
+	outObject = Array.isArray(inObject) ? [] : {};
+
+	for (key in inObject) {
+		value = inObject[key];
+
+		// Recursively (deep) copy for nested objects, including arrays
+		outObject[key] = deepCopy(value);
+	}
+
+	return outObject;
+}
 
 
 function queryDB(sql) {


### PR DESCRIPTION
After querying records and toggling between two different encounter records, some fields were retaining values from the previously selected encounter. It seems like this was from fields that were null in the new selection and therefore didn't have a value to overwrite the previous selection's value for that field. My solution was to reset the value of all inputs before loading the new record.

Similarly but for an unrelated cause, after editing and saving a field value, the entry form's `.fieldValues` property and the query's `.queryResult` were being tied together by a common reference. I added a `deepCopy()` global function to `bhims.js` and call it when updating `.fieldValues` after save. To be safe, I'm also now passing a `deepCopy()` to `fillFieldValues()` since it doesn't need a reference to the original object.

Lastly, a completely unrelated but small change: I changed the order of promise-returning functions to avoid problems with `getTableSortColumns()` throwing a mysterious but persistent error over slow connections. I've also changed the `.then()` chain to `.always()` so the page will still load.