### PR TITLE
fix saving first entry of accordion and displaying dependent accordions

### DIFF
--- a/web/js/bhims-entry.js
+++ b/web/js/bhims-entry.js
@@ -958,9 +958,14 @@ var BHIMSEntryForm = (function() {
 			//	several cards
 			if (typeof(value) === 'object' && value !== null) { // corresponds to an accordion
 				// Loop through each object and add a card/fill fields 
-				const $accordion = $('.accordion:not(.hidden)')
-					.filter((_, el) => {return $(el).data('table-name') === key})
-				if (!$accordion.length) continue;//if the accordion is hidden, ignore it
+				const $accordion = $('.accordion').filter((_, el) => $(el).data('table-name') === key);
+
+				//if the accordion is hidden, ignore it
+				if (
+					!$accordion.length || 
+					($accordion.is('.hidden') && !$accordion.is('.collapse'))
+				) continue;
+				
 				for (const index in value) {
 					const $card = this.addNewCard($accordion, index);
 					const inputValues = value[index];

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -18,8 +18,8 @@ var BHIMSQuery = (function(){
 		this.encounterIDs = [];
 		this.fieldsFull = false;
 		this.anonymizedDefaults = {
-			first_name: 'Anonymoys',
-			last_name: 'Person',
+			//first_name: 'Anonymous',
+			//last_name: 'Person',
 			phone_number: '555-5555',
 			email_address: 'someone@abc.com' 
 		};
@@ -1083,9 +1083,12 @@ var BHIMSQuery = (function(){
 				//	relationship for this table and this encounter. In that case, the id will 
 				//	remain undefined. Otherwise, set the ID so the item can be updated
 				if (entryForm.fieldValues[tableName] != undefined) {
-					if (index in entryForm.fieldValues[tableName]) {
+					const queryRecord = _this.queryResult[_this.selectedID];
+					if (tableName in queryRecord && index in queryRecord[tableName] && index in entryForm.fieldValues[tableName]) {
 						// Get DB row ID from queryResult because entryForm.fieldValues doesn't have it
-						tableUpdates[index].id = _this.queryResult[_this.selectedID][tableName][index].id; // will be undefined if this is a new card
+						tableUpdates[index].id = (queryRecord[tableName][index] || {}).id; // will be undefined if this is a new card
+					} else {
+						tableUpdates[index].id = undefined;
 					}
 				} 
 				tableUpdates[index].values[fieldName] = inputValue;
@@ -1445,8 +1448,9 @@ var BHIMSQuery = (function(){
 						break;
 					}
 				}	
+				$(targetField).val(collapsed ? 0 : 1).change();
 			}
-			$(targetField).val(collapsed ? 0 : 1).change();
+			
 		}
 	}
 


### PR DESCRIPTION
When editing a record on the query page, users could save a new one-to-many record (e.g., structures, property) if one already existed. If a user was adding the first one from the query page, however, line 1088 `_this.queryResult[_this.selectedID][tableName][index].id` would throw an error because the object at `index` didn't exist in the `queryResult`. 

Also discovered two unrelated issues that would have caused problems displaying data:
1. In `fillFieldValues()` of `bhims-entry.js` any hidden accordion would be ignored and their fields aren't filled, but this included hidden `.collapse`s. All dependent collapses start off as hidden, so this included structure and property accordions. Now only hidden accordions _without_ the `.collapse` class are ignored.
2. The boolean dependent target field for accordion collapses were always being set to 'No', even if there were data to show. This was because of line 1453, which was intended to set the collapse just for `.field-containers`, not accordion collapses. I moved that line inside the `if` closure, so it'll only be called if there are dependent `.input-fields`.