### PR TITLE
Show encounters in review card if no assessment record created

### DIFF
--- a/web/js/bhims-dashboard.js
+++ b/web/js/bhims-dashboard.js
@@ -19,16 +19,24 @@ function configureReviewCard() {
 		management_classification_code: 'Management classification'
 	};
 	const ratingFieldNames = Object.keys(ratingColumns).sort();
-
+	
 	// Query all records where at least one of the rating fields is null
 	const sql = `
 		SELECT
-			encounter_id, 
+			encounters.id AS encounter_id,
 			${ratingFieldNames.join(', ')}
-		FROM assessment 
-		INNER JOIN encounters ON assessment.encounter_id=encounters.id 
+		FROM encounters 
+		LEFT JOIN assessment ON assessment.encounter_id=encounters.id 
 		WHERE 
+<<<<<<< Updated upstream
 			${ratingFieldNames.map(c => c + ' IS NULL').join(' OR ')} 
+=======
+			(probable_cause_code IS NOT NULL AND management_classification_code IS NULL) OR  
+			(
+				coalesce(management_classification_code, -1) <> 1 AND --not an observation  
+				(${ratingFieldNames.map(c => c + ' IS NULL').join(' OR ')})
+			)
+>>>>>>> Stashed changes
 		ORDER BY start_date
 	`;
 

--- a/web/js/bhims-dashboard.js
+++ b/web/js/bhims-dashboard.js
@@ -28,15 +28,12 @@ function configureReviewCard() {
 		FROM encounters 
 		LEFT JOIN assessment ON assessment.encounter_id=encounters.id 
 		WHERE 
-<<<<<<< Updated upstream
 			${ratingFieldNames.map(c => c + ' IS NULL').join(' OR ')} 
-=======
 			(probable_cause_code IS NOT NULL AND management_classification_code IS NULL) OR  
 			(
 				coalesce(management_classification_code, -1) <> 1 AND --not an observation  
 				(${ratingFieldNames.map(c => c + ' IS NULL').join(' OR ')})
 			)
->>>>>>> Stashed changes
 		ORDER BY start_date
 	`;
 


### PR DESCRIPTION
If a user never altered an assessment field, there wouldn't necessarily be an assessment record. Previously, I had been (inner) joining `encounters` _to_ `assessment`, and encounters without an associated assessment record won't be included. Instead, I'm not `LEFT JOIN`ing `assesment` and any records with a null `encounter_id` need review