### PR TITLE
Create improper reactions table

### DIFF
--- a/pg_create_tables.sql
+++ b/pg_create_tables.sql
@@ -215,6 +215,14 @@ CREATE TABLE people (
     residency_code INTEGER, 
     sex_codes INTEGER REFERENCES sex_codes(code) ON DELETE RESTRICT ON UPDATE CASCADE
 );
+CREATE TABLE improper_reactions (
+    id SERIAL PRIMARY KEY,
+    encounter_id INTEGER REFERENCES encounters ON DELETE CASCADE,
+    improper_reaction_code INTEGER REFERENCES improper_reaction_codes(code) ON DELETE RESTRICT ON UPDATE CASCADE,
+    other_improper_reaction_description VARCHAR(255),
+    display_order INTEGER,
+    UNIQUE(encounter_id, display_order)
+);
 
 --UI meta tables
 CREATE TABLE data_entry_pages (

--- a/web/bhims-entry.html
+++ b/web/bhims-entry.html
@@ -30,6 +30,10 @@
 		integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
 		crossorigin=""></script>
 
+	<!-- select2 -->
+	<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+	<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+
 	<!-- custom css -->
 	<link rel="stylesheet" href="css/bhims.css">
 	<link rel="stylesheet" href="css/bhims-entry.css">

--- a/web/css/bhims-entry.css
+++ b/web/css/bhims-entry.css
@@ -289,14 +289,19 @@ the required-indicatior-explanation can still be on the right*/
     max-width: 100%;
     flex: 1 1 auto;
     height: 30px;
-    background-color: rgba(0,0,0,0);
     outline: -webkit-focus-ring-color auto 0px;
     -webkit-box-shadow: none;
     border-color: rgba(0,0,0,0);
-    font-size: 14px;
-    transition: all 0.3s ease-out;
-    border-bottom: 2px solid rgba(0,0,0,0.2);
     text-indent: 5px;
+    transition: all 0.3s ease-out;
+}
+.input-field,
+.bhims-select2 ~ .select2.select2-container--default .select2-selection--multiple {
+	border: none; /*set border: none first to undoe select2 default style*/
+	border-bottom: 2px solid rgba(0,0,0,0.2);
+	background-color: transparent;
+	font-size: 14px;
+	border-radius: 0;
 }
 
 .input-field.large-field {
@@ -306,22 +311,16 @@ the required-indicatior-explanation can still be on the right*/
 	max-width: 50%;
 }
 
-.input-field:not(textarea):hover {
-	/*background-color: hsla(1, 0%, 100%, 0.3);*/
+.input-field:not(textarea):hover,
+.bhims-select2 ~ .select2.select2-container--default .select2-selection--multiple:hover {
+	border: none; 
 	border-bottom: 2px solid rgba(0,0,0,0.5);
-	/*color: rgba(0,0,0,0.6);*/
 }
-
-/*.input-field:not(textarea):hover::placeholder {
-  color: rgba(0,0,0,0.5);
-}*/
-
-.input-field:not(textarea):focus {
-	/*background-color: hsla(1, 0%, 100%, 0.7);
-	box-shadow: inset 0px 1px 6px 0px hsla(1, 0%, 100%, 0.3);*/
-	border-bottom: 2px solid rgba(0,0,0,0.7) !important;
+.input-field:not(textarea):focus,
+.bhims-select2 ~ .select2.select2-container--default .select2-selection--multiple:hover {
+	border: none;
+	border-bottom: 2px solid rgba(0,0,0,0.7);
 	color: black;
-	/*font-size: 15px;*/
 }
 /*input.input-field:focus {
 	font-size: 15px;
@@ -330,7 +329,8 @@ select.input-field:focus::placeholder {
 	font-size: 15px;
 }*/
 
-.input-field.error {
+.input-field.error,
+.bhims-select2.error ~ .select2-container--default {
 	border: 2px solid rgba(255, 0, 0, 0.3);
 	box-shadow: 0px 0px 7px 2px hsl(0deg 62% 43% / 50%);
 }
@@ -436,11 +436,61 @@ select.input-field:focus::placeholder {
 
 .input-field:placeholder-shown ~ .field-sub-label, 
 .input-field:placeholder-shown ~ .field-label,
-select.input-field.default ~ .field-label {
+select.input-field.default:not(.bhims-select2) ~ .field-label {
 	visibility: hidden;
 	transform: translateY(-10px);
 	color: hsl(1, 0%, 50%);
 }
+
+/*select2 custom styling*/
+.bhims-select2 ~ .select2-container--default .select2-selection--multiple 
+	.select2-selection__choice {/*the selected item pill*/
+	background: none;
+	border: solid rgb(40, 40, 40) 1.5px;
+	border-radius: 2rem;
+	transition: all .2s;
+}
+.bhims-select2 ~ .select2-container--default .select2-selection--multiple 
+.select2-selection__choice__remove { /* the remove button */
+	border: none;
+	color: black;
+	border-radius: 1.1em;
+	top: 0.2em;
+	width: 1.1rem;
+	height: 1.1rem;
+	transition: background 0.2s;
+	background-color: transparent;
+}
+.bhims-select2 ~ .select2-container--default .select2-selection--multiple 
+.select2-selection__choice__remove:hover {
+	background: rgba(255, 255, 255, 0.3);
+}
+.bhims-select2 ~ .select2-container--default .select2-selection--multiple 
+.select2-selection__choice__remove span { /*the x*/
+	font-size: 1.5rem;
+	position: relative;
+	top: -.7rem;
+	left: -.05rem;
+}
+
+/*uneditable styling*/
+/*.bhims-select2 ~ .select2.select2-container--default .select2-selection--multiple*/
+.bhims-select2:disabled ~ .select2.select2-container--default .select2-selection--multiple,
+.bhims-select2:disabled ~ .select2.select2-container--default .select2-selection--multiple:hover {
+	border-bottom: none;
+}
+.bhims-select2:disabled ~ .select2-container--default .select2-selection--multiple .select2-selection__choice {
+	padding: 0;
+	border: none;
+	font-style: italic;
+}
+/*separate each item with a pipe since there's no border to distinguish them*/
+.bhims-select2:disabled ~ .select2-container--default .select2-selection--multiple .select2-selection__choice:not(:last-of-type)::after {
+	content: '|';
+	color: black;
+	font-style: normal;
+}
+/*-----------------------*/
 
 select.input-field.default,
 .input-field::placeholder,
@@ -467,7 +517,7 @@ textarea.narrative-field::placeholder {
 }
 
 input.input-field:valid + .required-indicator,
-select.input-field:not(.default) + .required-indicator,
+select.input-field:not(.default) ~ .required-indicator,
 textarea.input-field:valid + .required-indicator {
 	opacity: 0;
 }

--- a/web/css/query.css
+++ b/web/css/query.css
@@ -228,7 +228,7 @@ body {
 .select2-container--open {
 	z-index: 5000;
 }
-.select2-container > .select2-dropdown {
+.select2-container > .select2-dropdown.bhims-query-select2-dropdown-container {
 	background: rgb(0,0,0);
 	color: white;
 }

--- a/web/js/bhims-entry.js
+++ b/web/js/bhims-entry.js
@@ -21,7 +21,8 @@ let UNIT_PER_METER_MAP = new Map([
 	["ft", 3.2808399],
 	["yd", 1.0936132],
 	["m", 1],
-])
+]);
+var MULTIPLE_SELECT_ENTRY_CLASS = 'bhims-select2';
 
 var BHIMSEntryForm = (function() {
 	
@@ -357,7 +358,7 @@ var BHIMSEntryForm = (function() {
 									inputFieldAttributes += ` step="${fieldInfo.html_step}"`;
 								if (fieldInfo.html_input_type == 'datetime-local') 
 									inputFieldAttributes +=' pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"';
-								if (fieldInfo.css_class.includes('bhims-select2'))
+								if (fieldInfo.css_class.includes(MULTIPLE_SELECT_ENTRY_CLASS))
 									inputFieldAttributes += ' multiple="true"';
 								const inputTagClosure = inputTag != 'input' ? `</${inputTag}>` : ''; 
 								const required = fieldInfo.required === 't';
@@ -683,7 +684,7 @@ var BHIMSEntryForm = (function() {
 						// 	_this.goToPage(lastPageIndex + 1, true);
 						// } 
 					}
-					for (const el of $('.bhims-select2')) {
+					for (const el of $(`.${MULTIPLE_SELECT_ENTRY_CLASS}`)) {
 						const $select = $(el);
 						$select.select2({
 							width: '100%',
@@ -1421,7 +1422,7 @@ var BHIMSEntryForm = (function() {
 			(_, el) => {
 				const $el = $(el);
 				const $hiddenParent = $el.parents('.collapse:not(.show, .row-details-card-collapse), .card.cloneable, .field-container.disabled, .hidden');
-				if (!($el.hasClass('bhims-select2') ? $el.val().length : $el.val()) && $hiddenParent.length === 0) {
+				if (!($el.hasClass(MULTIPLE_SELECT_ENTRY_CLASS) ? $el.val().length : $el.val()) && $hiddenParent.length === 0) {
 					$el.addClass('error');
 				} else {
 					$el.removeClass('error');
@@ -3171,7 +3172,7 @@ var BHIMSEntryForm = (function() {
 				}
 
 				// Handle multiple choice selects
-				for (const input of $('.bhims-select2')) {
+				for (const input of $(`.${MULTIPLE_SELECT_ENTRY_CLASS}`)) {
 					const [statements, params] = _this.getMultipleSelectSQL(input);
 					sqlStatements = [...sqlStatements, ...statements];
 					sqlParameters = [...sqlParameters, ...params];

--- a/web/js/bhims.js
+++ b/web/js/bhims.js
@@ -422,13 +422,12 @@ function getEnvironment() {
 /*
 Load configuration values from the database
 */
-function loadConfigValues() {
+function loadConfigValues(config) {
 
-	let config = {};
-	queryDB('SELECT property, data_type, value FROM config')
+	return queryDB('SELECT property, data_type, value FROM config')
 		.done(queryResultString => {
-			if (this.queryReturnedError(queryResultString)) {
-				print('Problem querying config values');
+			if (queryReturnedError(queryResultString)) {
+				print('Problem querying config values: ' + queryResultString);
 			} else {
 				for (const {property, data_type, value, ...rest} of $.parseJSON(queryResultString)) {
 					config[property] = 
@@ -439,7 +438,6 @@ function loadConfigValues() {
 				}
 			}
 		})
-	return config;
 }
 
 

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -45,7 +45,7 @@ var BHIMSQuery = (function(){
 
 		// Find any multiple selects and flatten the data
 		let queryCopy = deepCopy(this.queryResult[this.selectedID]);
-		for (const input of $('.bhims-select2')) {
+		for (const input of $(`.${MULTIPLE_SELECT_ENTRY_CLASS}`)) {
 			const $select = $(input);
 			const fieldName = input.name;
 			queryCopy[fieldName] = (queryCopy[fieldName] || []).flat();
@@ -274,7 +274,7 @@ var BHIMSQuery = (function(){
 				Object.entries(entryForm.fieldInfo).flatMap( 
 					// return [table name, field name] if it's a multiple select, otherwise return an empty array
 					// 	so that the whole returned array can be flattened and null results will be dropped
-					([fieldName, info]) => (info.css_class || '').includes('bhims-select2') ? 
+					([fieldName, info]) => (info.css_class || '').includes(MULTIPLE_SELECT_ENTRY_CLASS) ? 
 						[[info.table_name, fieldName]] : // wrap in double brackets for flatMap() to remove the first set
 						[] // and collapse any null results
 				)
@@ -618,7 +618,7 @@ var BHIMSQuery = (function(){
 		}
 
 		// disable multiple selects
-		$('.bhims-select2').prop('disabled', disableEdits);
+		$(`.${MULTIPLE_SELECT_ENTRY_CLASS}`).prop('disabled', disableEdits);
 	}
 
 
@@ -1107,7 +1107,7 @@ var BHIMSQuery = (function(){
 					}
 				} 
 				tableUpdates[index].values[fieldName] = inputValue;
-			} else if ($input.is('.bhims-select2')) { 
+			} else if ($input.is(`.${MULTIPLE_SELECT_ENTRY_CLASS}`)) { 
 				// Add a DELETE statement to remove any existing records, 
 				//	then just insert whatever the current values are
 				sqlStatements.push(`DELETE FROM ${tableName} WHERE encounter_id=$1;`)

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -43,7 +43,14 @@ var BHIMSQuery = (function(){
 			$select.val($select.find('option').first().attr('value'));
 		}
 
-		entryForm.fillFieldValues(deepCopy(this.queryResult[this.selectedID]));//entryForm.fieldValues);
+		// Find any multiple selects and flatten the data
+		let queryCopy = deepCopy(this.queryResult[this.selectedID]);
+		for (const input of $('.bhims-select2')) {
+			const $select = $(input);
+			const fieldName = input.name;
+			queryCopy[fieldName] = (queryCopy[fieldName] || []).flat();
+		}
+		entryForm.fillFieldValues(queryCopy);
 
 		// All distance values in the DB should be in meters so make sure the units match that
 		$('.short-distance-select').val('m')
@@ -52,9 +59,9 @@ var BHIMSQuery = (function(){
 
 
 	/*
-	Helper function to uery the database to find the primary key for each 
+	Helper function to query the database to find the primary key for each 
 	table. This is really only necessary for bears and reactions, which
-	both have primary keys from two columns, a order column specific 
+	both have primary keys from two columns, an order column specific 
 	to the encounter and the encounter_id
 	*/
 	Constructor.prototype.getTableSortColumns = function() {
@@ -262,42 +269,54 @@ var BHIMSQuery = (function(){
 			// Get all table names from accordions
 			const oneToManyTables = $('.accordion').map((_, el) => {return $(el).data('table-name')}).get();
 			const encounterIDClause = `encounters.id IN (${Object.keys(this.queryResult).join(',')})`
+			// get a list of all the multiple choice select fields
+			const selectMultipleFields = Object.fromEntries(
+				Object.entries(entryForm.fieldInfo).flatMap( 
+					// return [table name, field name] if it's a multiple select, otherwise return an empty array
+					// 	so that the whole returned array can be flattened and null results will be dropped
+					([fieldName, info]) => (info.css_class || '').includes('bhims-select2') ? 
+						[[info.table_name, fieldName]] : // wrap in double brackets for flatMap() to remove the first set
+						[] // and collapse any null results
+				)
+			);
 			for (const tableName of this.joinedDataTables) {
-				/*var tableWhereClauses = [];
-				for (const fieldName in sqlQueryParameters[tableName]) {
-					const value = sqlQueryParameters[tableName][fieldName].value;
-					var operator = sqlQueryParameters[tableName][fieldName].operator;
-					const clause = `${tableName}.${fieldName} ${operator} ${value}`;
-					encountersWhereClauses.push(clause);
-				}*/
 				// construct WHERE statement in the format "WHERE encounters.id IN (...) AND <tableName>.<fieldName>..." 
 				//	unless there are no query params for this table. If that's the case just use "WHERE encounters.id IN (...)"
 				const tableWhereClauseString = whereClauses[tableName] ? 'AND ' + whereClauses[tableName].join(' AND ') : '';
 				const whereString = `WHERE ${encounterIDClause} ${tableWhereClauseString}`;
 				const sql = `SELECT ${tableName}.* FROM ${tableName} INNER JOIN encounters ON encounters.id=${tableName}.encounter_id ${whereString} ORDER BY ${tableName}.${this.tableSortColumns[tableName]}`;
 				const deferred = queryDB(sql);
+
 				deferred.done( queryResultString => {
 					if (queryReturnedError(queryResultString)) { 
 							console.log(`error querying ${tableName}: ${queryResultString}`);
 					} else { 
 						const result = $.parseJSON(queryResultString);
 						//this.queryResult[tableName] = {};
-						for (const row of result) {
-							for (const columnName in row) {
-								if ((entryForm.fieldInfo[columnName] || {}).has_pii === 't' && this.anonymizedDefaults[columnName]) {
-									row[columnName] = this.anonymizedDefaults[columnName];
-									this.ignorePIIFields = true;
+						if (tableName in selectMultipleFields) {
+							const fieldName = selectMultipleFields[tableName];
+							const sortedResult = (result[0] || {}).display_order ? 
+								result.sort((row1, row2) => parseInt(row1.display_order) - parseInt(row2.display_order)) :
+								result;
+							const encounterID = result[0].encounter_id;
+							this.queryResult[encounterID][fieldName] = sortedResult.map(row => row[fieldName]);
+						} else {
+							for (const row of result) {
+								for (const columnName in row) {
+									if ((entryForm.fieldInfo[columnName] || {}).has_pii === 't' && this.anonymizedDefaults[columnName]) {
+										row[columnName] = this.anonymizedDefaults[columnName];
+										this.ignorePIIFields = true;
+									}
 								}
+								const encounterID = row.encounter_id;
+								if (oneToManyTables.includes(tableName)) {
+									if (!this.queryResult[encounterID][tableName]) this.queryResult[encounterID][tableName] = [];
+									this.queryResult[encounterID][tableName].push({...row});
+								} else {
+									this.queryResult[encounterID] = {...this.queryResult[encounterID], ...row};
+								}
+								//if (!this.queryResult[tableName][encounterID]) this.queryResult[tableName][encounterID] = {};	
 							}
-							const encounterID = row.encounter_id;
-							if (oneToManyTables.includes(tableName)) {
-								if (!this.queryResult[encounterID][tableName]) this.queryResult[encounterID][tableName] = [];
-								this.queryResult[encounterID][tableName].push({...row});
-							} else {
-								this.queryResult[encounterID] = {...this.queryResult[encounterID], ...row};
-							}
-							//if (!this.queryResult[tableName][encounterID]) this.queryResult[tableName][encounterID] = {};
-							
 						}
 					}
 					
@@ -347,7 +366,7 @@ var BHIMSQuery = (function(){
 					if ($optionElement.hasClass('string-match-query-option')) {
 						// text, textarea, tel, or email
 						const $operatorElement = $optionElement.siblings('.query-option-operator');
-						const fieldValue = fieldParams.value.replace(/'/g, '');
+						const fieldValue = fieldParams.value.toString().replace(/'/g, '');
 						if (fieldParams.operator === '=') {
 							// e.g., field = 'value'
 							$optionElement.val(fieldValue);
@@ -420,7 +439,7 @@ var BHIMSQuery = (function(){
 							$operatorElement.val(fieldParams.operator);
 						}
 					} else if ($optionElement.hasClass('select2-no-tag')) {
-						$optionElement.val(fieldParams.value.replace(/\(|\)/g, '').split(','))
+						$optionElement.val(fieldParams.value.toString().replace(/\(|\)/g, '').split(','))
 					} else {
 						console.log('could not understand type of option for ' + fieldName)
 					}
@@ -597,6 +616,9 @@ var BHIMSQuery = (function(){
 				.find('.uneditable-units-text')
 					.text(displayValue);
 		}
+
+		// disable multiple selects
+		$('.bhims-select2').prop('disabled', disableEdits);
 	}
 
 
@@ -735,13 +757,6 @@ var BHIMSQuery = (function(){
 	/*
 	*/
 	Constructor.prototype.loadSelectedEncounter = function() {
-		
-		// close any open cards
-		/*$('#row-details-pane').find('.row-details-card-collapse.show')
-			.removeClass('show')
-			.siblings()
-				.find('.card-link')
-				.addClass('collapsed');*/
 
 		showLoadingIndicator('loadSelectedEncounter');
 
@@ -1031,13 +1046,16 @@ var BHIMSQuery = (function(){
 			return;
 		}
 
-		var selectedEncounterData = this.queryResult[this.selectedID];
+		const encounterID = this.selectedID;
+		var selectedEncounterData = this.queryResult[encounterID];
 
 		//TODO: need to handle attachment changes/new attachments
 		//TODO: also need to make sure all required fields are filled in somehow 
 
-		var oneToOneUpdates = {};
-		var oneToManyUpdates = {};
+		var oneToOneUpdates = {},
+			oneToManyUpdates = {},
+			sqlStatements = [],
+			sqlParameters = [];
 		//var fileUploads = {};
 		for (const input of $dirtyInputs) {
 			const $input = $(input);
@@ -1068,9 +1086,6 @@ var BHIMSQuery = (function(){
 			if ($accordion.length) {
 				// If this is the first time a field has been changed in this 
 				//	table, oneToManyUpdates[tableName] will be undefined
-				/*var updateStorageVar = tableName === 'attachments' ? fileUploads : oneToManyUpdates;
-				if (!oneToManyUpdates[tableName]) updateStorageVar[tableName] = {};
-				const tableUpdates = updateStorageVar[tableName];*/
 				if (!oneToManyUpdates[tableName]) oneToManyUpdates[tableName] = {};
 				const tableUpdates = oneToManyUpdates[tableName];
 
@@ -1092,6 +1107,16 @@ var BHIMSQuery = (function(){
 					}
 				} 
 				tableUpdates[index].values[fieldName] = inputValue;
+			} else if ($input.is('.bhims-select2')) { 
+				// Add a DELETE statement to remove any existing records, 
+				//	then just insert whatever the current values are
+				sqlStatements.push(`DELETE FROM ${tableName} WHERE encounter_id=$1;`)
+				sqlParameters.push([encounterID]);
+
+				const [statements, params] = entryForm.getMultipleSelectSQL(input, encounterID);
+				sqlStatements = [...sqlStatements, ...statements];
+				sqlParameters = [...sqlParameters, ...params];
+
 			} else {
 				if (!oneToOneUpdates[tableName]) oneToOneUpdates[tableName] = {};
 				oneToOneUpdates[tableName][fieldName] = inputValue;
@@ -1103,8 +1128,6 @@ var BHIMSQuery = (function(){
 		oneToOneUpdates.encounters.last_edited_by = entryForm.username;
 		oneToOneUpdates.encounters.datetime_last_edited = getFormattedTimestamp();
 		
-		var sqlStatements = [];
-		var sqlParameters = [];
 		for (const tableName in oneToOneUpdates) {
 			const updates = oneToOneUpdates[tableName];
 			// If this is just a normal table update (not part of a 1-to-many relationship), 
@@ -1472,7 +1495,7 @@ var BHIMSQuery = (function(){
 				for (const row of $.parseJSON(queryResultString)) {
 					reactionCodesTable[row.code] = {...row};
 				}
-				const reactionRows = this.queryResult[this.selectedID].reactions;
+				const reactionRows = this.queryResult[this.selectedID].reactions || [];
 				if (reactionRows.length) {
 					for (const i in reactionRows) {
 						// Get reaction code


### PR DESCRIPTION
A list of arbitrary length of improper reactions is now captured by a single multiple-choice select2 field. Each selected option maps to a record in an `improper_reactions` table. When saving a new encounter record, a row is inserted for each selection. When modifying an existing encounter from the query page, all existing `improper_reactions` rows for the current encounter are deleted and replaced with newly inserted rows. This prevents the need to keep track of which `improper_reaction` selection corresponds to which database record when a user modifies the field.  

Rather than adding a new configuration field in `data_entry_fields`, multiple-choice selects are signified by a utility class `bhims-select2`. Any field with this class will automatically have the `multiple` HTML attribute set and `.select2()` called on it. 

Closes issue #19 