### PR TITLE
Add case sensitive query toggle

### DIFF
--- a/web/css/bhims.css
+++ b/web/css/bhims.css
@@ -177,6 +177,13 @@ button > img {
 
 
 /* Toggle switch */
+.slider-container .slider-label {
+  height: 40px;
+  line-height: 40px;
+  vertical-align: middle;
+  margin-bottom: 0;
+  margin-right: 10px;
+}
 .switch {
   position: relative;
   display: inline-block;

--- a/web/css/query.css
+++ b/web/css/query.css
@@ -50,7 +50,7 @@ body {
 }
 #query-options-drawer-body {
 	width: 100%;
-	height: calc(100% - 100px);
+	height: calc(100% - 160px);
 }
 .tabs { 
 	float: none;
@@ -114,7 +114,7 @@ body {
 		- 60px /*header menu*/
 		- 10px /*drawer padding*/
 		- 60px /*tab labels*/
-		- 100px /*drawer footer*/
+		- 160px /*drawer footer*/
 	);
 	margin-top: 60px;
 	/*column-width: 300px;*/
@@ -371,7 +371,7 @@ body {
 
 #query-options-drawer-footer {
 	width: 100%;
-	height: 80px;
+	height: 160px;
 	padding: 10px;
 	display: none;/*hide when dropdown is closed*/
 	justify-content: center;
@@ -385,6 +385,7 @@ body {
 	justify-content: space-between;
 	height: 100%;
 	align-items: center;
+	flex-wrap: wrap;
 }
 #query-options-drawer-footer-content > *:not(.run-query-button) {
 	margin: 0 40px;

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -363,7 +363,13 @@ var BHIMSQuery = (function(){
 			//this.setReactionFieldsFromQuery();
 			// set query options
 			for (const tableName in queryParams.where) {
+				
 				const tableParams = queryParams.where[tableName];
+				
+				// set queryOptions here so query drawer state can be appropriately set when 
+				//	$optionElement.blur() is called
+				this.queryOptions.where[tableName] = {...tableParams};
+				
 				for (const fieldName in tableParams) {
 					const $optionElement = $(`#query-option-${fieldName}`);
 					
@@ -459,10 +465,9 @@ var BHIMSQuery = (function(){
 							.parent()
 							.addClass('hidden');
 					$optionElement.closest('.query-option-container').removeClass('hidden');
-					$('#copy-query-link-button').removeClass('hidden');
-					$optionElement.change();
+					$('#copy-query-link-button').removeClass('invisible');
+					$optionElement.blur();
 				}
-				this.queryOptions.where[tableName] = {...queryParams.where[tableName]};
 			}
 
 		});

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -1686,14 +1686,26 @@ var BHIMSQuery = (function(){
 	}
 
 
-	Constructor.prototype.onQueryOptionChange = function(e) {
-		
+	/*
+	Helper function to show/hide the copy query link button. This is called 
+	when a query option or the case-sensitive switch changes 
+	*/
+	Constructor.prototype.toggleCopyQueryLinkButton = function() {
 		// If this was the last query option, hide the copy-permalink button
 		var queryOptionsSpecified = false;
 		for (const tableName in _this.queryOptions.where) {
-			if (Object.keys(_this.queryOptions.where[tableName]).length) queryOptionsSpecified = true;
+			if (Object.keys(_this.queryOptions.where[tableName]).length) {
+				queryOptionsSpecified = true;
+				break;
+			}
 		}
 		$('#copy-query-link-button').toggleClass('invisible', !queryOptionsSpecified);
+	}
+
+
+	Constructor.prototype.onQueryOptionChange = function(e) {
+		
+		_this.toggleCopyQueryLinkButton();
 		
 		// Make the tab label appear selected
 		const $target = $(e.target);
@@ -2287,7 +2299,10 @@ var BHIMSQuery = (function(){
 					$('.query-option-input-field').blur(_this.onQueryOptionChange);
 
 					// When the user clicks the case-sensitive switch, run the result count query
-					$('#case-sensitive-slider-container input[type=checkbox]').change(() => {this.countQueryEncounters()});
+					$('#case-sensitive-slider-container input[type=checkbox]').change(e => {
+						this.countQueryEncounters();
+						this.toggleCopyQueryLinkButton();
+					});
 
 					//Select the first tab
 					$('.tabs').find('input[type="radio"]').first().click();

--- a/web/query.html
+++ b/web/query.html
@@ -76,6 +76,15 @@
 				</div>
 				<div id="query-options-drawer-footer">
 					<div id="query-options-drawer-footer-content">
+						<div class="w-100 d-flex justify-content-center">
+							<div id="case-sensitive-slider-container" class="slider-container">
+								<label class="slider-label">case-sensitive</label>
+								<label class="switch mx-10">
+									<input type="checkbox">
+									<span class="slider round"></span>
+								</label>
+							</div>
+						</div>
 						<div id="query-result-count" class="invisible">
 							returns <span id="query-encounters-count" class="query-result-count-text count-up"></span> of <span id="total-encounters-count" class="query-result-count-text"></span> encounters
 						</div>


### PR DESCRIPTION
Added toggle in `query.js`, `query.html`, and relevant `*.css`. This required adding a property to store whether the query should be case-sensitive in the top level of `this.queryOptions`, meaning all of the table-specific query information had to moved to a separate `where` object of `.queryOptions`. `export_data.py` then had to be updated to 1) handle case-insensitive queries and 2) use the new `queryOptions` format. I also added an event handler to trigger hiding/showing the query result count and copy-link button. Lastly, I peripherally updated the query option `onchange` behavior so that when query options are loaded from URL query parameters, the query options drawer's state is also updated. Namely, tab labels get the `active` class to show there are query criteria specified for that tab and the query result count and link button are shown.  