### PR TITLE
improvements to present mode

### DIFF
--- a/web/bhims.php
+++ b/web/bhims.php
@@ -189,13 +189,14 @@ if (isset($_POST['action'])) {
 
 	// Get username and user role
 	if ($_POST['action'] == 'getUser') {
+		$schema = getEnvironment() == 'dev' ? 'dev' : 'public';
 		if ($_SERVER['AUTH_USER']) {
 			$user = preg_replace("/^.+\\\\/", "", strtolower($_SERVER["AUTH_USER"]));
     	} else {
     		echo "ERROR: no auth_user";
     		exit();
     	}
-		$sql = "SELECT ad_username as username, role FROM users WHERE ad_username='$user'";
+		$sql = "SELECT ad_username as username, role FROM $schema.users WHERE ad_username='$user'";
 		$userRole = runQuery($dbhost, $dbport, $dbname, $username, $password, $sql);
 		
 		// Check if the query result is valid. If not, the user probably doesn't exist in the table yet

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -105,7 +105,7 @@ var BHIMSQuery = (function(){
 			SELECT 
 				DISTINCT table_name 
 			FROM information_schema.columns 
-			WHERE table_schema='public' AND column_name='encounter_id'
+			WHERE table_schema='${entryForm.dbSchema}' AND column_name='encounter_id'
 		;`;
 		return queryDB(tablesSQL).done( tableQueryResultString => {
 			const rightSideTables = $.parseJSON(tableQueryResultString);
@@ -1616,7 +1616,7 @@ var BHIMSQuery = (function(){
 		const sql = `
 			SELECT table_name 
 			FROM information_schema.tables 
-			WHERE table_schema='public' AND table_name LIKE '%_codes';
+			WHERE table_schema='${entryForm.dbSchema}' AND table_name LIKE '%_codes';
 		`;
 		// Since this array of deferreds will get returned before all the $.Deferreds get added, 
 		//	initialize with a dummy Deferred. When the for-loop is done, this dummy Deferred can 


### PR DESCRIPTION
These changes make the use of the `dev` schema more consistent for meta tables. It's also now used for the users table so I can alter user roles in the dev schema without affecting the production environment. I also removed the hard-coded 2022 date from dashboard queries for present mode. Note that the year used in present mode queries is still hardcoded and should probably be moved to a URL parameter. One other minor improvement is that I added an initial maximum zoom so that if there are only a few encounters at the beginning of the season within close proximity, the map won't zoom in beyond the viewable range for the basemap when calling `map.fitBounds()`