### PR TITLE
add max length for varchar fields

### DIFF
--- a/pg_create_tables.sql
+++ b/pg_create_tables.sql
@@ -374,6 +374,7 @@ CREATE TABLE data_entry_fields (
     html_min INTEGER,
     html_max INTEGER,
     html_step REAL,
+    max_length INTEGER,
     is_enabled BOOLEAN,
     description VARCHAR(255),
     UNIQUE(field_name, table_name)

--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -332,7 +332,10 @@ var BHIMSEntryForm = (function() {
 
 								var inputFieldAttributes = `id="${fieldInfo.html_id}" class="${fieldInfo.css_class}" name="${fieldInfo.field_name || ''}" data-table-name="${fieldInfo.table_name || ''}" placeholder="${fieldInfo.placeholder}" title="${fieldInfo.description}"`;
 								
-								var fieldLabelHTML = `<label class="field-label" for="${fieldInfo.html_id}">${fieldInfo.label_text || ''}</label>`
+								const characterCounterHTML = fieldInfo.max_length ?
+									`<span class="character-count-container hidden ml-2">(<em class="character-count"></em> of ${fieldInfo.max_length})</span>` : 
+									'';
+								var fieldLabelHTML = `<label class="field-label" for="${fieldInfo.html_id}">${fieldInfo.label_text || ''}${characterCounterHTML}</label>`
 								var inputTag = fieldInfo.html_input_type;
 								if (inputTag !== 'select' && inputTag !== 'textarea'){ 
 									inputFieldAttributes += ` type="${fieldInfo.html_input_type}"`;
@@ -356,6 +359,8 @@ var BHIMSEntryForm = (function() {
 									inputFieldAttributes += ` max="${fieldInfo.html_max}"`;
 								if (fieldInfo.html_step) 
 									inputFieldAttributes += ` step="${fieldInfo.html_step}"`;
+								if (fieldInfo.max_length && fieldInfo.html_input_type === 'text')
+									inputFieldAttributes += ` data-max-length=${fieldInfo.max_length}`;
 								if (fieldInfo.html_input_type == 'datetime-local') 
 									inputFieldAttributes +=' pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"';
 								if (fieldInfo.css_class.includes(MULTIPLE_SELECT_ENTRY_CLASS))
@@ -1414,7 +1419,7 @@ var BHIMSEntryForm = (function() {
 	Constructor.prototype.validateFields = function($parent, focusOnField=true) {
 
 		// If the user has disabled validation, just return true to indicate that they're all valid
-		if ($('#disable-required-slider-container input[type=checkbox]').is(':checked')) return true;
+		const validationDisabled = $('#disable-required-slider-container input[type=checkbox]').is(':checked');
 
 		const $fields = $parent
 			.find('.field-container:not(.disabled)')
@@ -1422,10 +1427,24 @@ var BHIMSEntryForm = (function() {
 			(_, el) => {
 				const $el = $(el);
 				const $hiddenParent = $el.parents('.collapse:not(.show, .row-details-card-collapse), .card.cloneable, .field-container.disabled, .hidden');
-				if (!($el.hasClass(MULTIPLE_SELECT_ENTRY_CLASS) ? $el.val().length : $el.val()) && $hiddenParent.length === 0) {
+				// Only check for empty fields if validation is enabled (it can be disabled by admins)
+				if (!validationDisabled) {
+					if (!($el.hasClass(MULTIPLE_SELECT_ENTRY_CLASS) ? $el.val().length : $el.val()) && $hiddenParent.length === 0) {
+						$el.addClass('error');
+					} else {
+						$el.removeClass('error');
+					}
+				}
+				// Always check if a value exceeds the max length, regardless of whether validation is disabled
+				const maxLength = $el.data('max-length');
+				let valueLength = 0;
+				try {
+					valueLength = el.value.length;
+				} catch {
+					console.log('Could not get value length for field ' + el.id);
+				}
+				if (valueLength > maxLength) {
 					$el.addClass('error');
-				} else {
-					$el.removeClass('error');
 				}
 		});
 
@@ -1840,7 +1859,31 @@ var BHIMSEntryForm = (function() {
 	When a user types anything in a text field, remove the error class
 	*/
 	Constructor.prototype.onInputFieldKeyUp = function(e) {
-		$(e.target).removeClass('error');
+
+		const $el = $(e.target);
+		const maxLength = $el.data('max-length');
+		const valueLength = $el.val().length;
+		if (maxLength && valueLength && valueLength > maxLength) {
+			// Show a message if the user pressed any key other than delete or backspace
+			const keyCode = e.keyCode || e.charCode;
+			if (!(keyCode == 8 || keyCode == 46)) { 
+				const message = 
+				`You've entered a value that exceeds the maximum number of characters for this field (${maxLength}).` + 
+				' If you need to add more detail to your response, you can specify that in the narrative description' + 
+				' of the encounter.';
+				showModal(message, 'Value Exceeds Maximum Field Length');
+			}
+			$el.addClass('error');
+		} else {
+			$el.removeClass('error');
+		}
+
+		// show character counter and update (if it exists)
+		$el.closest('.field-container')
+			.find('.character-count-container')
+				.removeClass('hidden')
+				.find('.character-count')
+					.text(valueLength);
 	}
 
 


### PR DESCRIPTION
Fields with `varchar` datatype in the database previously had no limit on the length of the response a user could type in the entry form. A field in the `data_entry_fields` table now stores a max length value. When the form is loaded, the `max_length` value is stored in `data-max-length`. As a user types, they are shown the number of characters used and the maximum allowed. If they exceed limit, they receive a warning message, triggered in the `keyup` event. I also added max length check in `validateFields()`, which is always checked even if the "Disable required fields" slider is checked.

I decided not to use the `maxlength` HTML attribute since all this does is prevent a user from entering a value greater than the length set. It does so silently, so there's no feedback for the user and there's no way to detect that the max length has been reached/exceeded.