### PR TITLE
Fix silent DB submission errors

### DIFF
--- a/web/js/bhims.js
+++ b/web/js/bhims.js
@@ -191,7 +191,7 @@ function showPermissionDeniedAlert() {
 Helper function to check a Postgres query result for an error
 */
 function queryReturnedError(queryResultString) {
-	return queryResultString.trim().startsWith('ERROR') || queryResultString.trim() === '["query returned an empty result"]';
+	return queryResultString.match(/^[\s["]*ERROR/) || queryResultString.trim() === '["query returned an empty result"]';
 }
 
 

--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -3290,7 +3290,7 @@ var BHIMSEntryForm = (function() {
 					cache: false
 				}).done(queryResultString => {
 					if (queryReturnedError(queryResultString)) {
-						showModal(`An unexpected error occurred while saving data to the database: ${queryResultString.trim()}.\n\nTry reloading the page. The data you entered will be automatically reloaded (except for attachments).`, 'Unexpected error')
+						showModal(`An unexpected error occurred while saving data to the database: ${queryResultString.trim()}.<br><br>Try reloading the page. The data you entered will be automatically reloaded (except for attachments).`, 'Unexpected error')
 						return;
 					}
 


### PR DESCRIPTION
The helper function to catch errors from a PHP response string was not catching database errors. This probably happened as far back as May of 2023 when I updated the response to always be a JSON-encoded string. I probably just didn't catch it before because there weren't any DB errors when submitting data.