### PR TITLE
make accordion field values arrays, not objects

### DIFF
--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -1346,7 +1346,7 @@ var BHIMSEntryForm = (function() {
 
 			// If this is the first time a field has been changed in this 
 			//	accordion, this.fieldValues[tableName] will be undefined
-			if (!_this.fieldValues[tableName]) _this.fieldValues[tableName] = {};
+			if (!_this.fieldValues[tableName]) _this.fieldValues[tableName] = [];
 			const tableRows = _this.fieldValues[tableName];
 			
 			// Get the index of this card within the accordion
@@ -1400,7 +1400,7 @@ var BHIMSEntryForm = (function() {
 
 			// If this is the first time a field has been changed in this 
 			//	accordion, this.fieldValues[tableName] will be undefined
-			if (!_this.fieldValues[tableName]) _this.fieldValues[tableName] = {};
+			if (!_this.fieldValues[tableName]) _this.fieldValues[tableName] = [];
 			const tableRows = _this.fieldValues[tableName];
 			
 			// Get the index of this card within the accordion


### PR DESCRIPTION
When setting the fieldValues for an accordion that had no corresponding in-memory data, I was apparently using an object (` = {}`) instead of an array (`=[]`). Then when the page was reloaded and `fillFieldValues()` was called, it would check that a value was an array, not an object, to determine if an accordion card should be added. This might have actually been the problem with the reactions accordion too.