### PR TITLE
Fix attachment promise handling

### DIFF
--- a/web/bhims.php
+++ b/web/bhims.php
@@ -41,54 +41,56 @@ function runQueryWithinTransaction($conn, $queryStr, $parameters=array()) {
 }
 
 
-// function runCmd($cmd) {
-// 	// can't get this to work for python commands because conda throws
-// 	// an error in conda-script (can't import cli.main)
-	
-// 	$pipes = array();
-// 	$process = proc_open(
-// 		$cmd, 
-// 		array(
-// 			0 => array("pipe", "r"), //STDIN
-// 		    1 => array('pipe', 'w'), // STDOUT
-// 		    2 => array('pipe', 'w')  // STDERR
-// 		), 
-// 		$pipes,
-// 		NULL,
-// 		NULL,
-// 		array('bypass_shell' => true)
-// 	);
-
-// 	if (is_resource($process)) {
-
-// 	    $stdout = stream_get_contents($pipes[1]);
-// 	    fclose($pipes[1]);
-
-// 	    $stderr = stream_get_contents($pipes[2]);
-// 	    fclose($pipes[2]);
-
-// 	    $returnCode = proc_close($process);
-
-// 		return array(
-// 			"stdout" => $stdout,
-// 			"stderr" => $stderr
-// 		);
-
-// 	} else {
-// 		return false;
-// 	}
-// }
-
 function runCmd($cmd) {
-	$output = null;
-	$resultCode = null;
-	exec($cmd, $output, $resultCode);
-
-	return array(
-		$result => $output,
-		$resultCode => $resultCode
+	// can't get this to work for python commands because conda throws
+	// an error in conda-script (can't import cli.main)
+	
+	$pipes = array();
+	$process = proc_open(
+		$cmd, 
+		array(
+			0 => array("pipe", "r"), //STDIN
+		    1 => array('pipe', 'w'), // STDOUT
+		    2 => array('pipe', 'w')  // STDERR
+		), 
+		$pipes,
+		NULL,
+		NULL,
+		array('bypass_shell' => true)
 	);
+
+	$returnCode = proc_close($process);
+
+	if (is_resource($process)) {
+
+	    $stdout = stream_get_contents($pipes[1]);
+	    fclose($pipes[1]);
+
+	    $stderr = stream_get_contents($pipes[2]);
+	    fclose($pipes[2]);
+
+	    $returnCode = proc_close($process);
+
+		return array(
+			"stdout" => $stdout,
+			"stderr" => $stderr
+		);
+
+	} else {
+		return false;
+	}
 }
+
+// function runCmd($cmd) {
+// 	$output = null;
+// 	$resultCode = null;
+// 	exec($cmd, $output, $resultCode);
+
+// 	return array(
+// 		$result => $output,
+// 		$resultCode => $resultCode
+// 	);
+// }
 
 
 function deleteFile($filePath) {

--- a/web/bhims.php
+++ b/web/bhims.php
@@ -41,42 +41,53 @@ function runQueryWithinTransaction($conn, $queryStr, $parameters=array()) {
 }
 
 
-function runCmd($cmd) {
-	// can't get this to work for python commands because conda throws
-	// an error in conda-script (can't import cli.main)
+// function runCmd($cmd) {
+// 	// can't get this to work for python commands because conda throws
+// 	// an error in conda-script (can't import cli.main)
 	
-	$pipes = array();
-	$process = proc_open(
-		$cmd, 
-		array(
-			0 => array("pipe", "r"), //STDIN
-		    1 => array('pipe', 'w'), // STDOUT
-		    2 => array('pipe', 'w')  // STDERR
-		), 
-		$pipes,
-		NULL,
-		NULL,
-		array('bypass_shell' => true)
+// 	$pipes = array();
+// 	$process = proc_open(
+// 		$cmd, 
+// 		array(
+// 			0 => array("pipe", "r"), //STDIN
+// 		    1 => array('pipe', 'w'), // STDOUT
+// 		    2 => array('pipe', 'w')  // STDERR
+// 		), 
+// 		$pipes,
+// 		NULL,
+// 		NULL,
+// 		array('bypass_shell' => true)
+// 	);
+
+// 	if (is_resource($process)) {
+
+// 	    $stdout = stream_get_contents($pipes[1]);
+// 	    fclose($pipes[1]);
+
+// 	    $stderr = stream_get_contents($pipes[2]);
+// 	    fclose($pipes[2]);
+
+// 	    $returnCode = proc_close($process);
+
+// 		return array(
+// 			"stdout" => $stdout,
+// 			"stderr" => $stderr
+// 		);
+
+// 	} else {
+// 		return false;
+// 	}
+// }
+
+function runCmd($cmd) {
+	$output = null;
+	$resultCode = null;
+	exec($cmd, $output, $resultCode);
+
+	return array(
+		$result => $output,
+		$resultCode => $resultCode
 	);
-
-	if (is_resource($process)) {
-
-	    $stdout = stream_get_contents($pipes[1]);
-	    fclose($pipes[1]);
-
-	    $stderr = stream_get_contents($pipes[2]);
-	    fclose($pipes[2]);
-
-	    $returnCode = proc_close($process);
-
-		return array(
-			"stdout" => $stdout,
-			"stderr" => $stderr
-		);
-
-	} else {
-		return false;
-	}
 }
 
 

--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -3146,21 +3146,24 @@ var BHIMSEntryForm = (function() {
 			}
 		}
 
+		const showFailedFilesMessage = failedFiles => {
+			const message = `
+				The following files could not be saved to the server:<br>
+				<ul>
+					<li>${failedFiles.join('</li><li>')}</li>
+				</ul>
+				<br>Your encounter was not saved as a result. Check your internet and network connection, and try to submit the encounter again.`;
+			hideLoadingIndicator();
+			showModal(message, 'File uploads failed');
+		}
+
 		// When all of the uploads have finished (or failed), check if any failed. 
 		//	If they all succeeded, then insert data
 		$.when(
 			...deferreds
-		).then(function() {
+		).done(function() {
 			if (failedFiles.length) {
-
-				const message = `
-					The following files could not be saved to the server:<br>
-					<ul>
-						<li>${failedFiles.join('</li><li>')}</li>
-					</ul>
-					<br>Your encounter was not saved as a result. Check your internet and network connection, and try to submit the encounter again.`;
-				hideLoadingIndicator();
-				showModal(message, 'File uploads failed');
+				showFailedFilesMessage(failedFiles);
 				return;
 			} else {
 				
@@ -3359,6 +3362,20 @@ var BHIMSEntryForm = (function() {
 					hideLoadingIndicator();
 				})
 			}
+		}).fail((failedXHR, status, error) => {
+			if (failedFiles.length) {
+				showFailedFilesMessage(failedFiles);
+			} else {
+				console.log(failedXHR.responseJSON || failedXHR.responseText);
+				showModal(
+					'An unexpected error occurred while saving data to the database. Make sure you' +
+					' are connected to the NPS network and try again. If the problem persists,' + 
+					' contact the database administrator.', 
+					'Database Error'
+				);
+				hideLoadingIndicator();
+			}
+			return; 
 		});
 	}
 


### PR DESCRIPTION
This PR addresses two issues: 

1. The `runCmd()` function was trying to check the result of `proc_open()` before calling `proc_close()`. Apparenly `proc_open()` blocks until you call `proc_close()`, so it wasn't possible to check the result first. 
2. If any of the promises created before generating SQL and writing to the DB (i.e., saving submission attempt time, attachments, getting park_form_id) were rejected, the `.then()` method of the `$.when()` promise was never called. This meant that the loading indicator would spin indefinitely. I changed `.then()` to `.done()` and added a `.fail()` callback as well.  