### PR TITLE
handle null values in onInputFieldKeyUP

### DIFF
--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -1862,7 +1862,7 @@ var BHIMSEntryForm = (function() {
 
 		const $el = $(e.target);
 		const maxLength = $el.data('max-length');
-		const valueLength = $el.val().length;
+		const valueLength = ($el.val() || '').length;
 		if (maxLength && valueLength && valueLength > maxLength) {
 			// Show a message if the user pressed any key other than delete or backspace
 			const keyCode = e.keyCode || e.charCode;


### PR DESCRIPTION
This was an oversight from PR #36. When a field's value is `null`, getting `.length` would throw an error, so just provide an empty string as a fallback value