### PR TITLE
fix misnamed var throwing error

### DIFF
--- a/web/js/entry-form.js
+++ b/web/js/entry-form.js
@@ -2366,7 +2366,7 @@ var BHIMSEntryForm = (function() {
 		const latDecimalSeconds = $('#input-lat_dec_sec').val();
 		const lonDecimalSeconds = $('#input-lon_dec_sec').val();
 
-		if (latDegrees && latDecimalMinutes && lonDegrees && lonDecimalMinutes && latDecimalSeconds && lonDecimalSeconds) {
+		if (latDegrees && latMinutes && lonDegrees && lonMinutes && latDecimalSeconds && lonDecimalSeconds) {
 			var [latDDD, lonDDD] = coordinatesToDDD(latDegrees, lonDegrees, latMinutes, lonMinutes, latDecimalSeconds, lonDecimalSeconds);
 			if (_this.markerIsOnMap()) { 
 				_this.confirmMoveEncounterMarker(latDDD, lonDDD);


### PR DESCRIPTION
I had apparently renamed `latMinutes` from `latDecimalMinutes` in the declaration but not when referencing it